### PR TITLE
move menu item into main Edit->Text submenu

### DIFF
--- a/menus/prettify.cson
+++ b/menus/prettify.cson
@@ -2,7 +2,7 @@
   {
     'label': 'Edit'
     'submenu': [
-      'label': 'text'
+      'label': 'Text'
       'submenu': [
         { 'label': 'Prettify HTML', 'command': 'prettify:prettify' }
       ]


### PR DESCRIPTION
Currently the Prettify HTML option appears under Edit->text (and the regular Edit->Text submenu shows as well). This one-character change causes the option to be merged into the existing Text submenu instead, which is neater.