### PR TITLE
Replace deprecated calls to Atom API

### DIFF
--- a/lib/prettify.coffee
+++ b/lib/prettify.coffee
@@ -12,5 +12,5 @@ prettify = (editor) ->
   sortableRanges.forEach (range) ->
     text = editor.getTextInBufferRange(range)
     text = beautify text,
-      "indent_size": 2
+      'indent_size': atom.config.get('editor.tabLength')
     editor.setTextInBufferRange(range, text)


### PR DESCRIPTION
Usage of WorkspaceView is deprecated in most cases (in fact atom throws warnings in as of version 0.187.0 when using this plugin). Therefore we're now using the new simplified API to gain access to the editor content and the list of commands.