### PR TITLE
update js-beautify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "atom": ">0.39.0"
   },
   "dependencies": {
-    "js-beautify": "~1.4.x"
+    "js-beautify": "~1.5.x"
   }
 }


### PR DESCRIPTION
Js-beautify is now at 1.5.5.

(should we do ^1.5.5 instead? or it’s already implied in ~1.5.x?)